### PR TITLE
Update AbilityExtension_VermilionHarvest.cs

### DIFF
--- a/Source/Revia_VanillaPsycastExpanded/VermilionHarvest/AbilityExtension_VermilionHarvest.cs
+++ b/Source/Revia_VanillaPsycastExpanded/VermilionHarvest/AbilityExtension_VermilionHarvest.cs
@@ -65,7 +65,7 @@ namespace Revia_VanillaPsycastExpanded
             }
         }
         public float bleedLoss = 0.75f;
-        public float psyfocusPerKill = 0.03f;
+        public float psyfocusPerKill = 0.15f;
         public float multiplierForBloodthirst = 0.4f;
         public FloatRange score = new FloatRange(0.7f, 2.5f);
         IntRange filthCount = new IntRange(2,6);


### PR DESCRIPTION
Part of the small changes to Verm harvest and fixing it's LOC - now returns more psyfocus while pounding you more with Psy Heat. Increasing the cast time, and including the rewording, since this doesn't scale with Psychic Sens, the return if you kill is likely valid.