### PR TITLE
bug fix and small change from Lord Navry

### DIFF
--- a/PsycastExpanded/Defs/HediffDefs/SkarnesCurse.xml
+++ b/PsycastExpanded/Defs/HediffDefs/SkarnesCurse.xml
@@ -16,9 +16,9 @@
 		<stages>
 			<li>
 				<statFactors>
-					<Revia_BleedRate>2</Revia_BleedRate>
 					<IncomingDamageFactor>1.5</IncomingDamageFactor>
 				</statFactors>
+				<totalBleedFactor>2</totalBleedFactor>
 			</li>
 		</stages>
 	</HediffDef>

--- a/Source/Main/Comps/CompLifeLeech.cs
+++ b/Source/Main/Comps/CompLifeLeech.cs
@@ -31,9 +31,9 @@ namespace ReviaRace.Comps
                 : null;
         }
 
-        public override void PostSpawnSetup(bool respawningAfterLoad)
+        public override void PostPostMake()
         {
-            base.PostSpawnSetup(respawningAfterLoad);
+            base.PostPostMake();
 
             var defaultLeech = ReviaRaceMod.GetDefaultLifeLeech(parent.def.defName);
             if (defaultLeech > 0 &&

--- a/Source/Main/HarmonyPatches/BleedRate_Patch.cs
+++ b/Source/Main/HarmonyPatches/BleedRate_Patch.cs
@@ -11,14 +11,14 @@ using Verse;
 
 namespace ReviaRace.HarmonyPatches
 {
-    [HarmonyPatch()]
-    internal static class BleedRate_Patch
-    {
-        static IEnumerable<MethodInfo> TargetMethods() => typeof(Hediff).AllSubclasses().Select(x => AccessTools.PropertyGetter(x, nameof(Hediff.BleedRate))).Where(x => x.DeclaringType != typeof(Hediff));
-        static void Postfix(Hediff __instance, ref float __result)
-        {
-            float multiplier = __instance.pawn?.GetStatValue(ReviaDefOf.Revia_BleedRate) ?? 1f;
-            __result *= multiplier;
-        }
-    }
+//    [HarmonyPatch()]
+//    internal static class BleedRate_Patch
+//    {
+//        static IEnumerable<MethodInfo> TargetMethods() => typeof(Hediff).AllSubclasses().Select(x => AccessTools.PropertyGetter(x, nameof(Hediff.BleedRate))).Where(x => x.DeclaringType != typeof(Hediff));
+//        static void Postfix(Hediff __instance, ref float __result)
+//        {
+//            float multiplier = __instance.pawn?.GetStatValue(ReviaDefOf.Revia_BleedRate) ?? 1f;
+//            __result *= multiplier;
+//        }
+//    }
 }


### PR DESCRIPTION
This is Lord Navry from Steam, submitting a couple small changes to establish communication.
Dr, NoLegs kindly asked me to make direct contributions out of my mods, though those will take time to reformat and tighten up their performance.

The bug fix for the LifeLeech ThingComp is as I described in the discussions on the mod page: it was not initializing when sanctified weapons were generated directly into pawn inventories, and shifting the initializing method to from on-spawn to on-make should correct that. This will allow Revia Templar npcs to benefit from lifeleech when they generate with sanctified weapons.

The other change is just to comment out the Revia Bleed Rate harmony patch for the time being, and replace it with an equivalent vanilla statistic in the VPE defs. I noticed a loss of about ~3 tps during some performance studies with my Revia mods, which was associated with the harmony patch on hediff bleed calculations. Presumably the harmony patch was still being pulled on hediffs with comps and all scars/bionics, creating a small load that scaled with the number of pawns (most generated pawns have scars or other non-simple hediffs).

Since no defs are changed, and no variables are removed, these should be 'safe' changes.
Implementing either change would then require the relevant assembly to be recompiled, of course.